### PR TITLE
Add Dictionary Item Cache Refreshing fixes #2

### DIFF
--- a/Moriyama.Cloud/Umbraco/Application/SqlBackedServerInstanceService.cs
+++ b/Moriyama.Cloud/Umbraco/Application/SqlBackedServerInstanceService.cs
@@ -1,12 +1,20 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
+using log4net.Repository.Hierarchy;
 using Moriyama.Cloud.Umbraco.Helper;
 using Moriyama.Cloud.Umbraco.Interfaces.Application;
+using umbraco;
 using umbraco.BusinessLogic;
+using umbraco.cms.businesslogic;
+using umbraco.interfaces.skinning;
+using Umbraco.Core;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Web;
 using UmbracoCms = Umbraco;
 
 namespace Moriyama.Cloud.Umbraco.Application
@@ -26,129 +34,248 @@ namespace Moriyama.Cloud.Umbraco.Application
 
         public void Register(string hostName)
         {
-            LogHelper.Info(typeof(SqlBackedServerInstanceService), "Registering host " + hostName);
+            try
+            {
+                LogHelper.Info(typeof(SqlBackedServerInstanceService), "Registering host " + hostName);
 
-            var connection = new SqlConnection(ConnectionString);
-            connection.Open();
+                using (var connection = new SqlConnection(ConnectionString))
+                {
+                    connection.Open();
 
-            // Create the database tables upon startup if they don't exist.
-            CreateSchema(connection);
+                    // Create the database tables upon startup if they don't exist.
+                    CreateSchema(connection);
 
-            // Run SQL to add the host to the list of alive hosts
-            RegisterHost(connection, hostName);
+                    // Run SQL to add the host to the list of alive hosts
+                    RegisterHost(connection, hostName);
 
-            // Cleanup any "old hosts"
-            DeleteHosts(connection);
+                    // Cleanup any "old hosts"
+                    DeleteHosts(connection);
 
-            connection.Close();
+                    connection.Close();
+                    connection.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error(typeof(SqlBackedServerInstanceService), "Register", ex);
+            }
         }
 
         public void Publish(string hostName, int documentId)
         {
-            var connection = new SqlConnection(ConnectionString);
-            connection.Open();
+            Publish(hostName,documentId,"Content");
+        }
+        
+        public void Publish(string hostName, int documentId, string refreshType)
+        {
+            try
+            {
+                using (var connection = new SqlConnection(ConnectionString))
+                {
+                    connection.Open();
 
-            var publishSql = TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.Publish.sql");
-            var command = new SqlCommand(publishSql, connection);
-            command.Parameters.AddWithValue("@DocumentId", documentId);
-            command.Parameters.AddWithValue("@PublishingHost", hostName);
+                    var publishSql = TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.Publish.sql");
+                    var command = new SqlCommand(publishSql, connection);
+                    command.Parameters.AddWithValue("@DocumentId", documentId);
+                    command.Parameters.AddWithValue("@PublishingHost", hostName);
+                    command.Parameters.AddWithValue("@RefreshType", refreshType);
+                    command.ExecuteNonQuery();
 
-            command.ExecuteNonQuery();
+                    LogHelper.Info(typeof(SqlBackedServerInstanceService),
+                        "Host " + hostName + " registered the publish of " + documentId);
 
-            LogHelper.Info(typeof(SqlBackedServerInstanceService), "Host " + hostName + " registered the publish of " + documentId);
+                    KeepAlive(connection, hostName);
+                    DeleteHosts(connection);
 
-            KeepAlive(connection, hostName);
-            DeleteHosts(connection);
-
-            connection.Close();
+                    connection.Close();
+                    connection.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error(typeof(SqlBackedServerInstanceService), "Publish", ex);
+            }
         }
 
         public void RefreshCache(string hostName)
         {
+            try
+            {
             LogHelper.Info(typeof(SqlBackedServerInstanceService), "Host " + hostName + " is refreshing it's cache");
 
-            var connection = new SqlConnection(ConnectionString);
-            connection.Open();
-
-            var processedPublishses = new List<Guid>();
-
-            var publishSql = TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.RefreshCache.sql");
-            var command = new SqlCommand(publishSql, connection);
-            command.Parameters.AddWithValue("@HostId", hostName);
-
-            var publishes = command.ExecuteReader();
-
-            while (publishes.Read())
+            using (var connection = new SqlConnection(ConnectionString))
             {
-                var documentId = (int)publishes["DocumentId"];
-                var identifier = (Guid)publishes["PublishId"];
+                connection.Open();
 
-                // do the actual cache refresh here!
-                var users = User.getAll();
-                var admin = users.SingleOrDefault(user => user.UserType.Alias == "admin");
-                if (admin != null)
+                var processedPublishses = new List<Guid>();
+
+                var publishSql =
+                    TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.RefreshCache.sql");
+
+                var command = new SqlCommand(publishSql, connection);
+                command.Parameters.AddWithValue("@HostId", hostName);
+
+                var publishes = command.ExecuteReader();
+
+                while (publishes.Read())
                 {
-                    var webService = new umbraco.presentation.webservices.CacheRefresher();
-                    webService.RefreshAll(new Guid(UmbracoCms.Web.Cache.DistributedCache.PageCacheRefresherId), admin.LoginName, admin.GetPassword());
+                    var documentId = (int) publishes["DocumentId"];
+                    var refreshType = (string) publishes["RefreshType"];
+                    var identifier = (Guid) publishes["PublishId"];
+
+                    LogHelper.Debug(typeof(SqlBackedServerInstanceService), "Host " + hostName + " is publishing " + documentId);
+                    if (refreshType == "Dictionary")
+                    {
+
+                        LogHelper.Info(typeof(SqlBackedServerInstanceService), "Host " + hostName + " is refreshing it's dictionary cache");
+                        RefreshDictionaryCache(identifier);
+                    }
+                    else
+                    {
+                        LogHelper.Info(typeof(SqlBackedServerInstanceService), "Host " + hostName + " is refreshing it's Content cache");
+                        umbraco.library.UpdateDocumentCache(documentId);
+                    }
+                    LogHelper.Debug(typeof(SqlBackedServerInstanceService), "Host " + hostName + " finished publishing");
+                    
+                    processedPublishses.Add(identifier);
                 }
-                processedPublishses.Add(identifier);
-            }
-            publishes.Close();
+                publishes.Close();
 
-            if (processedPublishses.Count > 0)
+                if (processedPublishses.Count > 0)
+                {
+                    var deleteSql =
+                        TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.DeletePublishes.sql");
+
+
+                    foreach (var publish in processedPublishses)
+                    {
+                        command = new SqlCommand("Delete from MoriyamaPublishes where PublishId = @Publishes", connection);
+                        command.Parameters.AddWithValue("@Publishes", publish);
+                        command.ExecuteNonQuery();
+                    }
+
+                    //command = new SqlCommand(deleteSql, connection);
+                    //command.Parameters.AddWithValue("@Publishes", string.Join(",", processedPublishses.ToArray()));
+                    //command.ExecuteNonQuery();
+
+                    LogHelper.Debug(typeof(SqlBackedServerInstanceService), "Host " + hostName + " removed processed publishses.");
+                }
+
+                KeepAlive(connection, hostName);
+                DeleteHosts(connection);
+
+                connection.Close();
+                connection.Dispose();
+                LogHelper.Debug(typeof(SqlBackedServerInstanceService), "Host " + hostName + " finished publishing");
+
+            }
+            }
+            catch (Exception ex)
             {
-                var deleteSql =
-                    TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.DeletePublishes.sql");
-
-                command = new SqlCommand(deleteSql, connection);
-                command.Parameters.AddWithValue("@Publishes", string.Join(",", processedPublishses.ToArray()));
-                command.ExecuteNonQuery();
+                LogHelper.Error(typeof(SqlBackedServerInstanceService), "RefreshCache", ex);
             }
-
-            KeepAlive(connection, hostName);
-            DeleteHosts(connection);
-
-            connection.Close();
         }
 
         private void KeepAlive(SqlConnection connection, string hostName)
-        {
+        {   
+            try
+            {
             var updateHostSql = TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.UpdateHost.sql");
             var command = new SqlCommand(updateHostSql, connection);
             command.Parameters.AddWithValue("@HostId", hostName);
             command.Parameters.AddWithValue("@AccessTime", DateTime.Now);
 
             command.ExecuteNonQuery();
+
+            LogHelper.Info(typeof(SqlBackedServerInstanceService), "Host " + hostName + " is alive");
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error(typeof(SqlBackedServerInstanceService), "RefreshCache", ex);
+            }
         }
 
         private void DeleteHosts(SqlConnection connection)
         {
+            try
+            {
             // TODO: extract this out to configuration somewhere
             // Ten Minutes
-            var expired = DateTime.Now.Subtract(TimeSpan.FromSeconds(600));
+            var expired = DateTime.Now.Subtract(TimeSpan.FromHours(12));
 
             // This will delete hosts that haven't been active for a while.
             var deleteHostSql = TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.DeleteHost.sql");
             var command = new SqlCommand(deleteHostSql, connection);
             command.Parameters.AddWithValue("@AccessTime", expired);
             command.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error(typeof(SqlBackedServerInstanceService), "RefreshCache", ex);
+            }
         }
 
         private void CreateSchema(SqlConnection connection)
         {
+             try
+            {
             // This will create the database tables upon first run
             var createTableSql = TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.Create.sql");
             var command = new SqlCommand(createTableSql, connection);
             command.ExecuteNonQuery();
+            }
+             catch (Exception ex)
+             {
+                 LogHelper.Error(typeof(SqlBackedServerInstanceService), "RefreshCache", ex);
+             }
         }
 
         private void RegisterHost(SqlConnection connection, string hostName)
         {
+             try
+            {
             var createHostSql = TextResourceReader.Instance.ReadResourceFile("Moriyama.Cloud.Umbraco.Sql.CreateHost.sql");
             var command = new SqlCommand(createHostSql, connection);
             command.Parameters.AddWithValue("@HostId", hostName);
             command.Parameters.AddWithValue("@AccessTime", DateTime.Now);
             command.ExecuteNonQuery();
+
+            LogHelper.Info(typeof(SqlBackedServerInstanceService), "Host " + hostName + " has been registered");
+            }
+             catch (Exception ex)
+             {
+                 LogHelper.Error(typeof(SqlBackedServerInstanceService), "RefreshCache", ex);
+             }
+        }
+
+        private void RefreshDictionaryCache(Guid publishId )
+        {
+            //currently the hashtable that contains the cache of dictionary items in memory
+            // only gets cleared when new items are added or removed
+            // there isn't the function to clear the cache
+            //sadly this is coming in 7.3
+            //ApplicationContext.Current.ApplicationCache.RuntimeCache.ClearCacheObjectTypes<IDictionaryItem>();
+          // so it would be a horrible hack here to temporarily create / update an existing DictionaryItem called "TempRefreshCache"...
+            // .... apologies
+            var ls = ApplicationContext.Current.Services.LocalizationService;
+            if (!ls.DictionaryItemExists("TempRefreshCache"))
+            {
+                DictionaryItem newItem = new DictionaryItem("TempRefreshCache");
+                foreach (var translation in newItem.Translations)
+                {
+                    translation.Value = publishId.ToString();
+                }
+                ls.Save(newItem);
+            }
+            else
+            {
+                var dicItem = ls.GetDictionaryItemByKey("TempRefreshCache");
+                   foreach (var translation in dicItem.Translations)
+                {
+                    translation.Value = publishId.ToString();
+                }
+              ls.Save(dicItem);
+            }
         }
     }
 }

--- a/Moriyama.Cloud/Umbraco/Event/PublishEvent.cs
+++ b/Moriyama.Cloud/Umbraco/Event/PublishEvent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Moriyama.Cloud.Umbraco.Application;
 using Umbraco.Core;
@@ -23,6 +23,10 @@ namespace Moriyama.Cloud.Umbraco.Event
             MediaService.Deleted += (sender, args) => MediaServiceEvent(args.DeletedEntities, "delete media");
             MediaService.Saved += (sender, args) => MediaServiceEvent(args.SavedEntities, "saved media");
             MediaService.Trashed += (sender, args) => MediaServiceEvent(new List<IMedia>(new[] { args.Entity }), "delete media");
+
+            LocalizationService.SavedDictionaryItem += (sender, args) => LocalizationServiceEvent(args.SavedEntities, "saved dictionary items");
+            LocalizationService.DeletedDictionaryItem += (sender, args) => LocalizationServiceEvent(args.DeletedEntities, "deleted dictionary items");
+      
         }
 
 
@@ -51,6 +55,20 @@ namespace Moriyama.Cloud.Umbraco.Event
             {
                 LogHelper.Info(typeof(PublishEvent), "Host " + host + " requesting cache update due to " + eventName + " of media item " + mediaItem.Id);
                 SqlBackedServerInstanceService.Instance.Publish(host, mediaItem.Id);
+            }
+
+        }
+
+        static void LocalizationServiceEvent(IEnumerable<IDictionaryItem> dics, string eventName)
+        {
+            var host = Environment.MachineName;
+
+            LogHelper.Info(typeof(PublishEvent), "Host " + host + " receieved a " + eventName + " event");
+
+            foreach (var dicItem in dics)
+            {
+                LogHelper.Info(typeof(PublishEvent), "Host " + host + " requesting cache update due to " + eventName + " of dictionary item " + dicItem.Id);
+                SqlBackedServerInstanceService.Instance.Publish(host, dicItem.Id);
             }
 
         }

--- a/Moriyama.Cloud/Umbraco/Event/PublishEvent.cs
+++ b/Moriyama.Cloud/Umbraco/Event/PublishEvent.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using ClientDependency.Core;
 using Moriyama.Cloud.Umbraco.Application;
+using umbraco.cms.businesslogic;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
@@ -24,23 +26,27 @@ namespace Moriyama.Cloud.Umbraco.Event
             MediaService.Saved += (sender, args) => MediaServiceEvent(args.SavedEntities, "saved media");
             MediaService.Trashed += (sender, args) => MediaServiceEvent(new List<IMedia>(new[] { args.Entity }), "delete media");
 
+            //the old api - new events below for 7.3+ currently dictionary only has a saving event
+            // which fires for every language value for a dictionary item
+            Dictionary.DictionaryItem.Saving += DictionaryItem_Saving;
+            Dictionary.DictionaryItem.Deleting += DictionaryItem_Deleting;
+
+            // the new api
             LocalizationService.SavedDictionaryItem += (sender, args) => LocalizationServiceEvent(args.SavedEntities, "saved dictionary items");
             LocalizationService.DeletedDictionaryItem += (sender, args) => LocalizationServiceEvent(args.DeletedEntities, "deleted dictionary items");
       
         }
 
-
-
         static void ContentServiceEvent(IEnumerable<IContent> documents, string eventName)
         {
             var host = Environment.MachineName;
 
-            LogHelper.Info(typeof(PublishEvent), "Host " + host + " receieved a " + eventName + " event");
+            LogHelper.Info(typeof(PublishEvent), "Host " + host + " received a " + eventName + " event");
 
             foreach (var document in documents)
             {
                 LogHelper.Info(typeof(PublishEvent), "Host " + host + " requesting cache update due to " + eventName + " of document " + document.Id);
-                SqlBackedServerInstanceService.Instance.Publish(host, document.Id);
+                SqlBackedServerInstanceService.Instance.Publish(host, document.Id,"Content");
             }
 
         }
@@ -49,12 +55,12 @@ namespace Moriyama.Cloud.Umbraco.Event
         {
             var host = Environment.MachineName;
 
-            LogHelper.Info(typeof(PublishEvent), "Host " + host + " receieved a " + eventName + " event");
+            LogHelper.Info(typeof(PublishEvent), "Host " + host + " received a " + eventName + " event");
 
             foreach (var mediaItem in media)
             {
                 LogHelper.Info(typeof(PublishEvent), "Host " + host + " requesting cache update due to " + eventName + " of media item " + mediaItem.Id);
-                SqlBackedServerInstanceService.Instance.Publish(host, mediaItem.Id);
+                SqlBackedServerInstanceService.Instance.Publish(host, mediaItem.Id,"Media");
             }
 
         }
@@ -63,14 +69,41 @@ namespace Moriyama.Cloud.Umbraco.Event
         {
             var host = Environment.MachineName;
 
-            LogHelper.Info(typeof(PublishEvent), "Host " + host + " receieved a " + eventName + " event");
+            LogHelper.Info(typeof(PublishEvent), "Host " + host + " received a " + eventName + " event");
 
             foreach (var dicItem in dics)
             {
-                LogHelper.Info(typeof(PublishEvent), "Host " + host + " requesting cache update due to " + eventName + " of dictionary item " + dicItem.Id);
-                SqlBackedServerInstanceService.Instance.Publish(host, dicItem.Id);
+                if (dicItem.ItemKey != "TempRefreshCache")
+                {
+                    LogHelper.Info(typeof (PublishEvent),
+                        "Host " + host + " requesting cache update due to " + eventName + " of dictionary item " + dicItem.Id);
+                    SqlBackedServerInstanceService.Instance.Publish(host, dicItem.Id, "Dictionary");
+                }
             }
 
+        }
+        void DictionaryItem_Deleting(Dictionary.DictionaryItem sender, EventArgs e)
+        {
+            var host = Environment.MachineName;
+            LogHelper.Info(typeof(PublishEvent), "Host " + host + " received a deleting dictionary - old api event");
+            LogHelper.Info(typeof(PublishEvent), "Host " + host + " requesting cache update due to deleting of dictionary item " + sender.id);
+            SqlBackedServerInstanceService.Instance.Publish(host, sender.id, "Dictionary");
+        }
+
+        void DictionaryItem_Saving(Dictionary.DictionaryItem sender, EventArgs e)
+        {
+            var host = Environment.MachineName;
+            if (sender.key != "TempRefreshCache")
+            {
+                LogHelper.Info(typeof (PublishEvent), "Host " + host + " received a saving dictionary - old api event");
+                LogHelper.Info(typeof (PublishEvent),
+                    "Host " + host + " requesting cache update due to saving of dictionary item " + sender.id);
+                SqlBackedServerInstanceService.Instance.Publish(host, sender.id, "Dictionary");
+            }
+            else
+            {
+                LogHelper.Info(typeof(PublishEvent), "Host " + host + " skipped saving refresh cache dictionary item");
+            }
         }
     }
 }

--- a/Moriyama.Cloud/Umbraco/Sql/Create.sql
+++ b/Moriyama.Cloud/Umbraco/Sql/Create.sql
@@ -1,4 +1,4 @@
-﻿Begin Transaction
+Begin Transaction
 
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[MoriyamaHosts]') AND type in (N'U'))
 	BEGIN
@@ -18,6 +18,7 @@ IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[Moriyama
 			[PublishTime] [datetime] NOT NULL,
 			[HostId] [nvarchar](50) NOT NULL,
 			[PublishId] [UniqueIdentifier] NOT NULL,
+			[RefreshType] [nvarchar](50) NOT NULL
 		CONSTRAINT [PK_dbo.Publishes] PRIMARY KEY CLUSTERED 
 		(
 			HostId, DocumentId
@@ -30,6 +31,12 @@ IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[Moriyama
 
 	END;
 
+IF NOT EXISTS ( SELECT 1 FROM information_schema.COLUMNS WHERE table_schema = 'dbo' AND TABLE_NAME = 'MoriyamaPublishes' AND column_Name = 'RefreshType' )
+	BEGIN
+		ALTER TABLE MoriyamaPublishes
+		ADD [RefreshType] [nvarchar](50);	
+		Exec('UPDATE MoriyamaPublishes Set [RefreshType] = '''' WHERE [RefreshType] IS NULL');
+	END;
 Commit Transaction
 
 

--- a/Moriyama.Cloud/Umbraco/Sql/Publish.sql
+++ b/Moriyama.Cloud/Umbraco/Sql/Publish.sql
@@ -1,4 +1,4 @@
-﻿Begin Transaction
+Begin Transaction
 IF OBJECT_ID('tempdb..#hosts') IS NOT NULL
     DROP TABLE #hosts
 
@@ -19,9 +19,9 @@ INSERT INTO #hosts (HostId)
 			Begin
 
     		INSERT INTO MoriyamaPublishes 
-    			(DocumentId, PublishTime, HostId, PublishId)
+    			(DocumentId, PublishTime, HostId, PublishId, RefreshType)
     		Values
-    			(@DocumentId, GETDATE(), @HostId, NewId())
+    			(@DocumentId, GETDATE(), @HostId, NewId(),@RefreshType)
 		End
 		
 		DELETE FROM #hosts Where HostId = @HostId


### PR DESCRIPTION
Adds a column to the MoriyamaRefresh table to allow different types of refreshes to be registered, adds 'Dictionary' refresh type, and hooks into Dictionary changing events, when server sees dictionary refresh types in the refresh table, it updates a dummy dictionary item causing all of the dictionary item cache to be refreshed, 7.3 will allow this to be neatened up. fixes #2